### PR TITLE
[Gen 518] [C4 154] RemoteOwner cannot receiver ether

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,6 +27,13 @@ jobs:
           forge --version
           forge build --sizes
         id: build
+      
+      - name: Run Forge test
+        env:
+          MAINNET_RPC_URL: ${{ secrets.MAINNET_RPC_URL }}
+        run: |
+          forge test
+        id: test
 
       - name: Install lcov
         uses: hrishikesh-kadam/setup-lcov@v1.0.0

--- a/src/RemoteOwner.sol
+++ b/src/RemoteOwner.sol
@@ -35,6 +35,13 @@ contract RemoteOwner is ExecutorAware {
    */
   event OriginChainOwnerSet(address owner);
 
+  /**
+   * @notice Emitted when ether is received to this contract via the `receive` function.
+   * @param from The sender of the ether
+   * @param value The value received
+   */
+  event Received(address from, uint256 value);
+
   /* ============ Variables ============ */
 
   /// @notice ID of the origin chain that dispatches the auction auction results and random number.
@@ -56,6 +63,13 @@ contract RemoteOwner is ExecutorAware {
     if (originChainId_ == 0) revert OriginChainIdZero();
     _originChainId = originChainId_;
     _setOriginChainOwner(__originChainOwner);
+  }
+
+  /* ============ Receive Ether Function ============ */
+
+  /// @dev Emits a `Received` event
+  receive() external payable {
+    emit Received(msg.sender, msg.value);
   }
 
   /* ============ External Functions ============ */

--- a/test/RemoteOwner.t.sol
+++ b/test/RemoteOwner.t.sol
@@ -20,6 +20,8 @@ import { RemoteOwnerCallEncoder } from "../src/libraries/RemoteOwnerCallEncoder.
 /// @dev See the "Writing Tests" section in the Foundry Book if this is your first time with Forge.
 /// https://book.getfoundry.sh/forge/writing-tests
 contract RemoteOwnerTest is Test {
+
+  event Received(address from, uint256 value);
   
   RemoteOwner account;
 
@@ -66,6 +68,13 @@ contract RemoteOwnerTest is Test {
     new RemoteOwner(1, address(this), address(0));
   }
 
+  function testReceiveEther() public {
+    vm.expectEmit();
+    emit Received(address(this), 1000);
+    (bool sent,) = address(account).call{value: 1000}(""); // send ether
+    assertEq(sent, true);
+  }
+
   function testExecute() public {
     (bool success, bytes memory result) = address(account).call(executeData);
     assertTrue(success, "was true");
@@ -99,7 +108,7 @@ contract RemoteOwnerTest is Test {
 
   function testSetOriginChainOwner() public {
     executeData = abi.encodePacked(abi.encodeWithSelector(account.setOriginChainOwner.selector, imposter), bytes32(uint256(0x1234)), uint256(1), originChainOwner);
-    (bool success, bytes memory returnData) = address(account).call(executeData);
+    (bool success,) = address(account).call(executeData);
     assertTrue(success, "was successful");
     assertEq(account.originChainOwner(), imposter);
   }

--- a/test/libraries/RemoteOwnerCallEncode.t.sol
+++ b/test/libraries/RemoteOwnerCallEncode.t.sol
@@ -20,7 +20,7 @@ contract RemoteOwnerTest is Test {
     function setUp() public {
         wrapper = new RemoteOwnerCallEncoderWrapper();
         target = makeAddr("target");
-        remoteOwner = RemoteOwner(makeAddr("remoteOwner"));
+        remoteOwner = RemoteOwner(payable(makeAddr("remoteOwner")));
         vm.etch(address(remoteOwner), "remoteOwner");
     }
 


### PR DESCRIPTION
- Add `receive() payable` function.
- Also updated actions to fail if tests fail

Fixes: https://github.com/code-423n4/2023-08-pooltogether-findings/issues/154