### PR TITLE
add missing natspec for RemoteOwnerCallEncoder

### DIFF
--- a/src/libraries/RemoteOwnerCallEncoder.sol
+++ b/src/libraries/RemoteOwnerCallEncoder.sol
@@ -3,7 +3,16 @@ pragma solidity ^0.8.19;
 
 import { RemoteOwner } from "../RemoteOwner.sol";
 
+/// @title RemoteOwnerCallEncoder
+/// @author G9 Software Inc.
+/// @notice Provides an interface to encode calldata for a RemoteOwner to execute.
 library RemoteOwnerCallEncoder {
+
+    /// @notice Encodes calldata for a RemoteOwner to execute on `target`.
+    /// @param target The target address that RemoteOwner will call with the given value and data
+    /// @param value The value that RemoteOwner will send to `target`
+    /// @param data The data that RemoteOwner will call `target` with
+    /// @return The encoded calldata
     function encodeCalldata(address target, uint256 value, bytes memory data) internal pure returns (bytes memory) {
         return abi.encodeWithSelector(
             RemoteOwner.execute.selector,


### PR DESCRIPTION
Also partially fixes:
[GEN-526](https://linear.app/generation/issue/GEN-526/c4-bot-[nc-40]-natspec-return-argument-is-missing)
[GEN-525](https://linear.app/generation/issue/GEN-525/c4-bot-[nc-39]-natspec-param-is-missing)